### PR TITLE
fix(basiccard-graph-upcomingevents): use calendarview for fetching events

### DIFF
--- a/samples/BasicCard-Graph-UpcomingEvents/src/adaptiveCardExtensions/service/Service.ts
+++ b/samples/BasicCard-Graph-UpcomingEvents/src/adaptiveCardExtensions/service/Service.ts
@@ -1,4 +1,6 @@
-import { graph } from "@pnp/graph/presets/all";
+import { graph } from "@pnp/graph";
+import '@pnp/graph/calendars';
+import '@pnp/graph/users';
 import { add, format } from 'date-fns';
 import { IEvent } from "../models/IEvent";
 
@@ -11,7 +13,8 @@ export class PnPService {
             days: days
         });
         console.log(futureDate);
-        const events = await graph.me.calendar.events.filter(`Start/DateTime ge '${today.toISOString()}' and End/DateTime le '${futureDate.toISOString()}'`).orderBy('Start/DateTime', true).get();
+        
+        const events = await graph.me.calendarView(today.toISOString(), futureDate.toISOString()).orderBy('Start/DateTime', true).get()
         events.map(event => {
             eventsArray.push(
                 {

--- a/samples/BasicCard-Graph-UpcomingEvents/src/adaptiveCardExtensions/service/Service.ts
+++ b/samples/BasicCard-Graph-UpcomingEvents/src/adaptiveCardExtensions/service/Service.ts
@@ -14,7 +14,7 @@ export class PnPService {
         });
         console.log(futureDate);
         
-        const events = await graph.me.calendarView(today.toISOString(), futureDate.toISOString()).orderBy('Start/DateTime', true).get()
+        const events = await graph.me.calendarView(today.toISOString(), futureDate.toISOString()).orderBy('Start/DateTime', true).get();
         events.map(event => {
             eventsArray.push(
                 {


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                        |
| New sample?     | no                             |
| Related issues? | |

## What's in this Pull Request?

Use the `calendarView` endpoint for fetching bookings instead of `events`. This is shorter, and also automatically handles repeat bookings.

This commit also changes the PnP import to use the presets in order to reduce bundle size.